### PR TITLE
Send all fields to Slack, not only strings

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	logrus "github.com/Sirupsen/logrus"
-	"github.com/johntdyer/slackrus"
 	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/johntdyer/slackrus"
 )
 
 func main() {
@@ -22,7 +23,7 @@ func main() {
 		Username:       "foobot",
 	})
 
-	logrus.WithFields(logrus.Fields{"foo": "bar", "foo2": "bar2"}).Warn("this is a warn level message")
+	logrus.WithFields(logrus.Fields{"foo": "bar", "foo2": 42}).Warn("this is a warn level message")
 	logrus.Info("this is an info level message")
 	logrus.Debug("this is a debug level message")
 }

--- a/slackrus.go
+++ b/slackrus.go
@@ -2,6 +2,8 @@
 package slackrus
 
 import (
+	"fmt"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/johntdyer/slack-go"
 )
@@ -76,16 +78,14 @@ func (sh *SlackrusHook) Fire(e *logrus.Entry) error {
 		for k, v := range e.Data {
 			slackField := &slack.Field{}
 
-			if str, ok := v.(string); ok {
-				slackField.Title = k
-				slackField.Value = str
-				// If the field is <= 20 then we'll set it to short
-				if len(str) <= 20 {
-					slackField.Short = true
-				}
+			slackField.Title = k
+			slackField.Value = fmt.Sprint(v)
+			// If the field is <= 20 then we'll set it to short
+			if len(slackField.Value) <= 20 {
+				slackField.Short = true
 			}
-			attach.AddField(slackField)
 
+			attach.AddField(slackField)
 		}
 		attach.Pretext = e.Message
 	} else {


### PR DESCRIPTION
Currently only field values of type `string` are sent to Slack. This patch send all fields attached to `logrus.Entry` using default string representation (`fmt.Sprint`).