### PR TITLE
Use inline slack.Client, allow for empty username

### DIFF
--- a/slackrus.go
+++ b/slackrus.go
@@ -11,10 +11,6 @@ const (
 	VERISON = "0.0.2"
 )
 
-var (
-	client *slack.Client
-)
-
 // SlackrusHook is a logrus Hook for dispatching messages to the specified
 // channel on Slack.
 type SlackrusHook struct {
@@ -26,7 +22,6 @@ type SlackrusHook struct {
 	Channel        string
 	IconEmoji      string
 	Username       string
-	c              *slack.Client
 }
 
 // Levels sets which levels to sent to slack
@@ -39,12 +34,6 @@ func (sh *SlackrusHook) Levels() []logrus.Level {
 
 // Fire -  Sent event to slack
 func (sh *SlackrusHook) Fire(e *logrus.Entry) error {
-	if sh.c == nil {
-		if err := sh.initClient(); err != nil {
-			return err
-		}
-	}
-
 	color := ""
 	switch e.Level {
 	case logrus.DebugLevel:
@@ -58,12 +47,11 @@ func (sh *SlackrusHook) Fire(e *logrus.Entry) error {
 	}
 
 	msg := &slack.Message{
-		Username: sh.Username,
-		Channel:  sh.Channel,
+		Username:  sh.Username,
+		Channel:   sh.Channel,
+		IconEmoji: sh.IconEmoji,
+		IconUrl:   sh.IconURL,
 	}
-
-	msg.IconEmoji = sh.IconEmoji
-	msg.IconUrl = sh.IconURL
 
 	attach := msg.NewAttachment()
 
@@ -94,16 +82,6 @@ func (sh *SlackrusHook) Fire(e *logrus.Entry) error {
 	attach.Fallback = e.Message
 	attach.Color = color
 
-	return sh.c.SendMessage(msg)
-
-}
-
-func (sh *SlackrusHook) initClient() error {
-	sh.c = &slack.Client{sh.HookURL}
-
-	if sh.Username == "" {
-		sh.Username = "SlackRus"
-	}
-
-	return nil
+	c := slack.NewClient(sh.HookURL)
+	return c.SendMessage(msg)
 }


### PR DESCRIPTION
Current client initialisation is not thread safe, as calls to `hook.Fire` are not protected by mutex (see [logrus/entry.go](https://github.com/Sirupsen/logrus/blob/master/entry.go#L88)). While fixing it realised there is no need to store `slack.Client` within the hook at all, as [the client](https://github.com/johntdyer/slack-go/blob/master/slack.go#L11) doesn't have any state, only an URL, hence can be inlined. 

Also, while refactoring, allowed to leave username empty. This is _very_ desired – when setting up incoming web hook in Slack one can specify default username and channel. If empty username is always overwritten with "SlackRus" this cannot be leveraged. 