### PR TITLE
Asynchronous sending message to Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ func main() {
   * IconURL
   * Username
   * Channel
-	* Asynchronous
+  * Asynchronous
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 slackrus
 ========
 
-Slack hook for [Logrus](https://github.com/Sirupsen/logrus). 
+Slack hook for [Logrus](https://github.com/Sirupsen/logrus).
 
 ## Use
 
@@ -41,17 +41,18 @@ func main() {
 
 #### Required
   * HookURL
-  
+
 #### Optional
   * IconEmoji
   * IconURL
   * Username
   * Channel
+	* Asynchronous
 
 ## Installation
 
     go get github.com/johntdyer/slackrus
-    
-## Credits 
+
+## Credits
 
 Based on hipchat handler by [nuboLAB](https://github.com/nubo/hiprus)

--- a/slackrus.go
+++ b/slackrus.go
@@ -24,6 +24,7 @@ type SlackrusHook struct {
 	Channel        string
 	IconEmoji      string
 	Username       string
+	Asynchronous   bool
 }
 
 // Levels sets which levels to sent to slack
@@ -83,5 +84,11 @@ func (sh *SlackrusHook) Fire(e *logrus.Entry) error {
 	attach.Color = color
 
 	c := slack.NewClient(sh.HookURL)
+
+	if sh.Asynchronous {
+		go c.SendMessage(msg)
+		return nil
+	}
+
 	return c.SendMessage(msg)
 }


### PR DESCRIPTION
Hi,

For some projects, I don't want logs to block while trying to send to Slack.  This pull request adds an option to specify 'Asynchronous', which means that the message will be attempted in the background, and fail silently if it fails at all.

It means if there are any issues with the Slack server, logs won't block.